### PR TITLE
make html not * the default selector

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ impl Config {
 
         let selector: String = match matches.values_of("selector") {
             Some(values) => values.collect::<Vec<&str>>().join(" "),
-            None => String::from("*"),
+            None => String::from("html"),
         };
 
         Some(Config {
@@ -51,7 +51,7 @@ impl Default for Config {
         Self {
             input_path: "-".to_string(),
             output_path: "-".to_string(),
-            selector: "*".to_string(),
+            selector: "html".to_string(),
             ignore_whitespace: true,
             pretty_print: true,
             text_only: false,
@@ -137,6 +137,7 @@ fn get_config<'a, 'b>() -> App<'a, 'b> {
         )
         .arg(
             Arg::with_name("selector")
+                .default_value("html")
                 .multiple(true)
                 .help("The CSS expression to select"),
         )


### PR DESCRIPTION
Currently if you leave off the selector argument the cli breaks. It
would be nice to have a sane default, like print the whole html
document. There are some places where Options are converted into
Strings, implying that * is supposed to be the default selector. This
change realises that implied intention, but decides html, which prints
the whole document, instead of *, which prints every tag recursively, is
a better default.