### PR TITLE
Improve display of code-blocks in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,3 +116,11 @@ $ curl --silent https://mgdm.net | htmlq --pretty '#posts'
     </li>
 [...]
 ```
+
+### Syntax highlighting with [`bat`](https://github.com/sharkdp/bat)
+
+```console
+$ curl -sL https://mdn.io/Array | htmlq '#description ~ *' | bat -l html
+```
+
+> ![Syntax highlighted output](https://user-images.githubusercontent.com/2346707/132520957-2098026d-7513-4771-a590-ca54c0e14f09.png)

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ $ curl --silent https://mgdm.net | htmlq --pretty '#posts'
 ### Syntax highlighting with [`bat`](https://github.com/sharkdp/bat)
 
 ```console
-$ curl -sL https://mdn.io/Array | htmlq '#description ~ *' | bat -l html
+$ curl -s example.com | htmlq 'body' | bat -l html
 ```
 
-> <img alt="Syntax highlighted output" width="700" src="https://user-images.githubusercontent.com/2346707/132520957-2098026d-7513-4771-a590-ca54c0e14f09.png" />
+> <img alt="Syntax highlighted output" width="700" src="https://user-images.githubusercontent.com/2346707/132675965-a299b2d8-b57d-41fd-86d1-baf871bdb69a.png" />

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # htmlq
-Like jq, but for HTML. Uses CSS selectors to extract bits of content from HTML files. Mozilla's MDN has a good <a href="https://developer.mozilla.org/en-US/docs/Learn/CSS/Introduction_to_CSS/Selectors">reference for CSS selector syntax</a>.
+Like [`jq`](https://stedolan.github.io/jq/), but for HTML. Uses [CSS selectors](https://developer.mozilla.org/en-US/docs/Learn/CSS/Introduction_to_CSS/Selectors) to extract bits of content from HTML files.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -123,4 +123,4 @@ $ curl --silent https://mgdm.net | htmlq --pretty '#posts'
 $ curl -sL https://mdn.io/Array | htmlq '#description ~ *' | bat -l html
 ```
 
-> ![Syntax highlighted output](https://user-images.githubusercontent.com/2346707/132520957-2098026d-7513-4771-a590-ca54c0e14f09.png)
+> <img alt="Syntax highlighted output" width="700" src="https://user-images.githubusercontent.com/2346707/132520957-2098026d-7513-4771-a590-ca54c0e14f09.png" />

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ $ curl --silent https://mgdm.net | htmlq --pretty '#posts'
 ### Syntax highlighting with [`bat`](https://github.com/sharkdp/bat)
 
 ```console
-$ curl -s example.com | htmlq 'body' | bat -l html
+$ curl --silent example.com | htmlq 'body' | bat --language html
 ```
 
-> <img alt="Syntax highlighted output" width="700" src="https://user-images.githubusercontent.com/2346707/132675965-a299b2d8-b57d-41fd-86d1-baf871bdb69a.png" />
+> <img alt="Syntax highlighted output" width="700" src="https://user-images.githubusercontent.com/2346707/132808980-db8991ff-9177-4cb7-a018-39ad94282374.png" />

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@ Like jq, but for HTML. Uses CSS selectors to extract bits of content from HTML f
 
 ## Installation
 
-```
+```sh
 cargo install htmlq
 ```
 
 ## Usage
 
-```
+```console
 $ htmlq -h
 htmlq 0.2.0
 Runs CSS selectors on HTML
@@ -38,7 +38,7 @@ $
 
 ### Using with cURL to find part of a page by ID
 
-```bash
+```console
 $ curl --silent https://www.rust-lang.org/ | htmlq '#get-help'
 <div class="four columns mt3 mt0-l" id="get-help">
         <h4>Get help!</h4>
@@ -61,7 +61,7 @@ $ curl --silent https://www.rust-lang.org/ | htmlq '#get-help'
 
 ### Find all the links in a page
 
-```bash
+```console
 $ curl --silent https://www.rust-lang.org/ | htmlq --attribute href a
 /
 /tools/install
@@ -79,7 +79,7 @@ $
 
 ### Get the text content of a post
 
-```
+```console
 $ curl --silent https://nixos.org/nixos/about.html | htmlq  --text .main
 
           About NixOS
@@ -100,7 +100,7 @@ to change that.  NixOS has many innovative features:
 
 (This is a bit of a work in progress)
 
-```
+```console
 $ curl --silent https://mgdm.net | htmlq --pretty '#posts'
 <section id="posts">
   <h2>I write about...

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@ Like [`jq`](https://stedolan.github.io/jq/), but for HTML. Uses [CSS selectors](
 
 ## Installation
 
-### Cargo
+### [Cargo](https://docs.rs/htmlq)
 
 ```sh
 cargo install htmlq
 ```
 
-### Homebrew
+### [Homebrew](https://formulae.brew.sh/formula/htmlq)
 
 ```sh
 brew install htmlq

--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ OPTIONS:
 
 ARGS:
     <selector>...    The CSS expression to select
-$
 ```
 
 ## Examples
@@ -82,7 +81,6 @@ https://blog.rust-lang.org/
 https://blog.rust-lang.org/2019/04/25/Rust-1.34.1.html
 https://blog.rust-lang.org/2018/12/06/Rust-1.31-and-rust-2018.html
 [...]
-$
 ```
 
 ### Get the text content of a post


### PR DESCRIPTION
This PR combines a bunch of cosmetic enhancements to the readme file, plus an extra example to showcase how [`bat`](https://github.com/sharkdp/bat) can be used to add syntax highlighting.

The latter includes a screenshot that's uploaded as a file attachment to https://github.com/mgdm/htmlq/pull/17#issuecomment-915206105, since I didn't feel comfortable asking the author to accept a 19 KB blob of uncompressible image data in addition to a bunch of lightweight improvements.