### PR TITLE
Add Scoop installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ cargo install htmlq
 brew install htmlq
 ```
 
+### [Scoop](https://scoop.sh/)
+
+```sh
+scoop install htmlq
+```
+
 ## Usage
 
 ```console


### PR DESCRIPTION
Scoop has added htmlq into their main repository as well: https://github.com/ScoopInstaller/Main/pull/3085