### PR TITLE
Add a basic Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+ARG ALPINE_VERSION=3.21
+ARG RUST_VERSION=1.85
+ARG HTMLQ_VERSION=0.4.0
+ARG TARGET=x86_64-unknown-linux-musl
+
+FROM rust:$RUST_VERSION-alpine$ALPINE_VERSION AS build
+ARG TARGET
+ARG HTMLQ_VERSION
+RUN apk add --no-cache musl-dev gcc
+RUN rustup target add "$TARGET"
+RUN cargo install htmlq --version "$HTMLQ_VERSION" --target "$TARGET" --root /htmlq-build
+RUN /htmlq-build/bin/htmlq --version
+
+FROM alpine:$ALPINE_VERSION AS release
+COPY --from=build /htmlq-build/bin/htmlq /usr/bin/


### PR DESCRIPTION
Add a Dockerfile to simplify distribution and deployment of `htmlq`.

Providing an official Dockerfile makes it significantly easier for users to quickly run `htmlq` in a consistent, isolated environment without manual setup. It also facilitates seamless integration into automated workflows and CI/CD pipelines.

Key benefits:

- Ensures consistent builds and reproducible environments.
- Simplifies deployment and usage across diverse systems.
- Enables straightforward integration with container-based CI/CD tools.
