### PR TITLE
Report invalid selectors without panicking

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -110,9 +110,15 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let remove_node_selector = config.remove_nodes.join(",");
 
-    document
-        .select(&config.selector)
-        .expect("Failed to parse CSS selector")
+    let selection = match document.select(&config.selector) {
+        Ok(selection) => selection,
+        Err(()) => {
+            eprintln!("Failed to parse CSS selector: {}", config.selector);
+            std::process::exit(2);
+        }
+    };
+
+    selection
         .inspect(|noderef| {
             let Ok(remove) = noderef.as_node().select_first(&remove_node_selector) else {
                 return;

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -36,3 +36,17 @@ cmd_success_tests!(
         "<div id=\"my-id\"></div>\n",
     ),
 );
+
+#[test]
+fn invalid_selector_reports_error_without_panicking() {
+    Command::cargo_bin("htmlq")
+        .unwrap()
+        .arg("div:has(h1)")
+        .write_stdin("<div><h1>h1</h1></div><div><p>p</p></div>")
+        .assert()
+        .code(2)
+        .stderr(
+            predicate::str::contains("Failed to parse CSS selector: div:has(h1)")
+                .and(predicate::str::contains("panicked").not()),
+        );
+}


### PR DESCRIPTION
Fixes #65.

## Problem

Unsupported CSS selectors such as `div:has(h1)` make htmlq panic while parsing the selector. The CLI exits 101 and can emit a Rust backtrace instead of a user-facing error.

## Change

Handle the selector parser error explicitly, print the exact invalid selector, and exit with status 2.

This does not add `:has` support or change successful selector behavior.

## Verification

- Reproduced the original exit 101 panic on current `master`
- Added a regression test requiring exit 2 and no panic
- `cargo test --all-targets` — 10 passed, 0 failed
- Manual invalid-selector check — exit 2, exact diagnostic, no panic
- Manual valid `div` selector check — output unchanged

## Risk

Low. The change affects only selector-parse failures and adds no dependency.
